### PR TITLE
Make filtering allowed headers case-insensitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to `knotx-repository-connector` will be documented in this f
 
 ## Unreleased
 List of changes that are finished but not yet released in any final version.
+- [PR-14](https://github.com/Knotx/knotx-repository-connector/pull/10) - Make filtering allowed headers case-insensitive
 
 ## 2.1.0
 

--- a/http/src/main/java/io/knotx/repository/http/HttpRepositoryConnector.java
+++ b/http/src/main/java/io/knotx/repository/http/HttpRepositoryConnector.java
@@ -215,7 +215,7 @@ class HttpRepositoryConnector {
 
   private MultiMap filteredHeaders(MultiMap headers) {
     return headers.names().stream()
-        .filter(AllowedHeadersFilter.create(configuration.getAllowedRequestHeadersPatterns()))
+        .filter(AllowedHeadersFilter.CaseInsensitive.create(configuration.getAllowedRequestHeaders()))
         .collect(MultiMapCollector.toMultiMap(o -> o, headers::getAll));
   }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For a reason we can use:
```
AllowedHeadersFilter.CaseInsensitive.create(strings);
```
I done refactor usage of AllowedHeadersFilter

See also previous [PR#10](https://github.com/Knotx/knotx-repository-connector/pull/10)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
[#7](https://github.com/Knotx/knotx-commons/issues/7) and [PR-8](https://github.com/Knotx/knotx-commons/pull/8)

## Screenshots (if appropriate)

## Upgrade notes (if appropriate)
<!-- What changes user have to do in order to migrate from the previous version to the version with this feature -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the [code style](/CONTRIBUTING.md#coding-conventions) of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.

---
I hereby agree to the terms of the Knot.x Contributor License Agreement.
